### PR TITLE
fix: Remove duplicate line for definitions

### DIFF
--- a/src/u1ws.md
+++ b/src/u1ws.md
@@ -72,8 +72,6 @@ The discussion posts are done in Discord threads. Click the 'Threads' icon on th
 
 ---
 
-Definitions/Terminology
-
 CIA Triad
 
 Regulatory Compliance


### PR DESCRIPTION
Removes a stray "Definitions / Terminology" line