### PR TITLE
fix: Duplicate links with && without trailing slashes in resources

### DIFF
--- a/scripts/generate_resources.sh
+++ b/scripts/generate_resources.sh
@@ -64,7 +64,7 @@ pull-links() {
             # - Add associative array containing links already added
             #   - Bash can't parse markdown links as associative array keys
             #   - use md5sum hashes
-            LINK_HASH=$(printf "%s" "${MARKDOWN_LINK,,}" | md5sum | cut -d ' ' -f1)
+            LINK_HASH=$(printf "%s" "${MARKDOWN_LINK,,}" | sed -E 's/\/([>\)])?$/\1/' | md5sum | cut -d ' ' -f1)
             if [[ -z "${ADDED_LINKS["$LINK_HASH"]}" ]]; then
                 [[ -n $UNIT && -n "$MARKDOWN_LINK" ]] && sed -i "/^## Unit $UNIT$/a- $MARKDOWN_LINK" "$RESOURCES_FILE"
                 [[ -z $UNIT && -n "$MARKDOWN_LINK" ]] && sed -i "/^## Misc$/a- $MARKDOWN_LINK" "$RESOURCES_FILE"


### PR DESCRIPTION
Duplicate links were ending up in `resources.md` when they were present with a trailing slash and without a trailing slash. 

![image](https://github.com/user-attachments/assets/2ccc1773-77f8-4747-a5bf-86607ff9ea1e)

I stripped the trailing slash with sed if it's there before calculating the link's md5 hash to prevent this.