### PR TITLE
Add issue generation script

### DIFF
--- a/.github/ISSUE_TEMPLATE/unit-bonus-body.md
+++ b/.github/ISSUE_TEMPLATE/unit-bonus-body.md
@@ -1,0 +1,240 @@
+# Example Bonus 🍒 from LAC Unit 1 Bonus
+
+---
+
+<div class="flex-container">
+        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
+    <p>
+        <h1>Unit 1 Bonus - VIM Fundamentals for Linux Sysadmins</h1>
+    </p>
+</div>
+
+> **NOTE:** This is an **optional** bonus section. You **do not** need to read it, but if you're interested in digging deeper, this is for you.
+
+## Module 1: Getting Started (Days 1-2)
+
+---
+
+### Day 1: First Contact with VIM
+
+**Segment 1: The Basics**
+
+1. Complete first section of `vimtutor`
+2. Learn essential commands:
+   - `vim filename` - Open/create file
+   - `i` - Enter insert mode
+   - `Esc` - Return to normal mode
+   - `:w` - Save changes
+   - `:q` - Quit
+   - `:wq` or `ZZ` - Save and quit
+   - `:q!` - Quit without saving
+
+**Segment 2: Building Muscle Memory**
+
+1. Create five different files
+2. Practice mode switching 50 times
+3. Write and save content in each file
+4. Practice recovering from common mistakes:
+   - Accidentally pressed keys in normal mode
+   - Forgot to enter insert mode
+   - Trying to quit without saving
+
+**Segment 3: First Real Task**
+
+1. Create a simple bash script template
+2. Add standard sections:
+   - Shebang line
+   - Comments
+   - Basic variables
+   - Simple functions
+3. Save and reopen multiple times
+
+### Day 2: Comfort Zone
+
+**Segment 1: More Basic Operations**
+
+1. Complete second section of `vimtutor`
+2. Practice quick save and exit combinations
+3. Learn to read VIM messages and errors
+4. Understand modes in depth:
+   - Normal mode
+   - Insert mode
+   - Visual mode (introduction)
+
+**Segment 2: Error Recovery**
+
+1. Create deliberate errors and fix them:
+   - Write without insert mode
+   - Exit without saving needed changes
+   - Get stuck in different modes
+2. Practice until you can recover without thinking
+
+**Segment 3: Real Config Practice**
+
+1. Copy `/etc/hosts` file
+2. Make various modifications:
+   - Add new host entries
+   - Modify existing entries
+   - Add comments
+   - Save different versions
+
+## Module 2: Navigation (Days 3-4)
+
+---
+
+### Day 3: Basic Movement
+
+**Segment 1: Core Movement Commands**
+
+- Master the basics:
+  - `h` - Left
+  - `j` - Down
+  - `k` - Up
+  - `l` - Right
+  - `w` - Next word
+  - `b` - Previous word
+  - `0` - Line start
+  - `$` - Line end
+
+**Segment 2: Movement Drills**
+
+1. Create a "movement course" file
+2. Practice moving between marked points
+3. Time your navigation speed
+4. Compete against your previous times
+
+**Segment 3: Applied Navigation**
+
+1. Navigate through `/etc/ssh/sshd_config`:
+   - Find specific settings
+   - Move between sections
+   - Locate comments
+   - Jump to line numbers
+
+### Day 4: Advanced Movement
+
+**Segment 1: Extended Movement**
+
+- Learn efficient jumps:
+  - `gg` - File start
+  - `G` - File end
+  - `{` - Previous paragraph
+  - `}` - Next paragraph
+  - `Ctrl+f` - Page down
+  - `Ctrl+b` - Page up
+
+**Segment 2: Speed Training**
+
+1. Work with a large configuration file
+2. Practice jumping between sections
+3. Find specific lines quickly
+4. Navigate through code blocks
+
+**Segment 3: Real-world Navigation**
+
+1. Work with system logs
+2. Jump between error messages
+3. Navigate through long configuration files
+4. Practice quick file browsing
+
+## Module 3: Essential Editing (Days 5-7)
+
+---
+
+### Day 5: Basic Editing
+
+**Segment 1: Edit Commands**
+
+- Master core editing:
+  - `x` - Delete character
+  - `dd` - Delete line
+  - `yy` - Copy line
+  - `p` - Paste after
+  - `P` - Paste before
+  - `u` - Undo
+  - `Ctrl + r` - Redo
+
+**Segment 2: Editing Drills**
+
+1. Create practice documents
+2. Delete and replace text
+3. Copy and paste sections
+4. Practice undo/redo chains
+
+**Segment 3: System File Editing**
+
+1. Work with `/etc/fstab` copy:
+   - Add mount points
+   - Remove entries
+   - Comment lines
+   - Fix formatting
+
+### Day 6: Intermediate Editing
+
+**Segment 1: Combined Commands**
+
+- Learn efficient combinations:
+  - `dw` - Delete word
+  - `d$` - Delete to line end
+  - `d0` - Delete to line start
+  - `cc` - Change whole line
+  - `cw` - Change word
+
+**Segment 2: Practical Application**
+
+1. Edit service configuration files
+2. Modify system settings
+3. Update network configurations
+4. Clean up log files
+
+**Segment 3: Speed Challenges**
+
+1. Timed editing tasks
+2. Configuration file cleanup
+3. Quick text transformation
+4. Error correction sprints
+
+### Day 7: Editing Mastery
+
+**Segment 1: Advanced Operations**
+
+- Master text objects:
+  - `ciw` - Change inner word
+  - `ci"` - Change inside quotes
+  - `di(` - Delete inside parentheses
+  - `yi{` - Yank inside braces
+
+**Segment 2: Integration Practice**
+
+1. Combine all learned commands
+2. Work with multiple files
+3. Practice common scenarios
+4. Time your operations
+
+## Daily Success Metrics
+
+---
+
+By end of each day, you should be able to:
+
+- Day 1: Open, edit, save, and exit files confidently
+- Day 2: Understand and recover from common errors
+- Day 3: Navigate small files without arrow keys
+- Day 4: Move through large files efficiently
+- Day 5: Perform basic edits without hesitation
+- Day 6: Combine movement and editing commands
+- Day 7: Edit configuration files with confidence
+
+## Practice Tips
+
+---
+
+1. Use `vimtutor` during breaks
+2. Disable arrow keys completely
+3. Keep a command log of new discoveries
+4. Time your editing operations
+5. Practice with real system files (copies)
+
+Remember: Focus on accuracy first, then build speed.
+ 
+## Downloads

--- a/.github/ISSUE_TEMPLATE/unit-intro-body.md
+++ b/.github/ISSUE_TEMPLATE/unit-intro-body.md
@@ -1,0 +1,112 @@
+# Example Intro from LAC Unit 1 Intro
+
+---
+
+# Unit 1
+
+## Overview
+
+### What is the skill/tech/concept we are dealing with?
+This unit introduces the foundational skills needed for effective Linux system administration with an emphasis on Red Hat Enterprise Linux (RHEL). It covers:
+
+- **Command-Line Proficiency:** Mastery of the shell environment is essential for routine tasks such as navigating the file system, managing processes, and automating scripts.
+
+- **Text Editing with VI/Vim:** Given that many RHEL systems use VI/Vim as the default editor for configuration and scripting, learners are introduced to these tools through practical exercises like using vimtutor and exploring interactive resources (e.g., VIM Adventures).
+
+- **Understanding the Linux File System:** The worksheet emphasizes the standard Linux file hierarchy—critical for managing files, permissions, and services in a Red Hat environment.
+
+- **Basic Utilities and System Management:** Along with the command-line and text editors, the unit touches on fundamental utilities that are pivotal for system configuration, troubleshooting, and maintenance on enterprise systems.
+
+## Learning Objectives
+
+1. **Master Command-Line Fundamentals:**  
+  - Develop proficiency in navigating the Linux command-line interface (CLI) for everyday system management tasks.  
+  - Learn how to execute commands to manipulate files, directories, and system processes efficiently. 
+
+2. **Understand the Linux File System:**  
+  - Grasp the structure and organization of the Linux file hierarchy.  
+  - Comprehend how the file system affects system configuration, security, and troubleshooting on Red Hat platforms. 
+
+3. **Gain Proficiency in Text Editing with VI/Vim:**  
+  - Acquire hands-on experience with vi/vim through guided exercises (e.g., vimtutor, VIM Adventures).  
+  - Learn to edit configuration files and scripts accurately, which is critical for system administration. 
+
+4. **Engage with Practical System Administration Tasks:**  
+  - Explore foundational utilities and commands essential for managing a Linux system.  
+  - Apply theoretical knowledge through real-world examples, discussion posts, and interactive resources to reinforce learning. 
+
+These objectives are designed to ensure that learners not only acquire technical competencies but also understand how these skills integrate into broader system administration practices in a Red Hat environment.
+
+## Relevance & Context
+
+### Why is it important to Linux Administrators/Engineers?
+The skills taught in this unit are indispensable for several reasons:
+
+- **Efficient System Management:**  
+  The RHEL environment is typically managed via the command line. Proficiency in the CLI, along with an in-depth understanding of the file system, is crucial for daily tasks like system configuration, package management (using tools such as YUM or DNF), and remote troubleshooting.
+
+- **Security and Stability:**  
+  Editing configuration files, managing system services, and monitoring logs are all critical tasks that ensure the secure and stable operation of RHEL systems. A robust understanding of these basics is necessary to mitigate risks and ensure compliance with enterprise security standards.
+
+- **Professional Certification & Career Growth:**  
+  For those pursuing certifications like the Red Hat Certified System Administrator (RHCSA) or Red Hat Certified Engineer (RHCE), these foundational skills are not only testable requirements but also a stepping stone for more advanced topics such as automation (using Ansible), container management (with Podman or OpenShift), and performance tuning.
+
+- **Operational Excellence:**  
+  In enterprise settings where uptime and rapid incident response are paramount, having a solid grasp of these fundamentals enables administrators to quickly diagnose issues, apply fixes, and optimize system performance—thereby directly impacting business continuity and service quality.
+
+## Prerequisites
+
+### Briefly mention concepts or skills the reader should already understand before starting the chapter.
+
+The unit assumes a basic level of computer literacy, meaning the learner is comfortable with fundamental computer operations. However, before achieving that level, one must have **digital literacy**. This involves:
+
+- **Familiarity with Computer Hardware:**  
+  Understanding what a computer is, how to power it on/off, and how to use basic peripherals (keyboard, mouse, monitor). This foundational comfort enables users to interact with a computer effectively.
+
+- **Basic Software Navigation:**  
+  Knowing how to use common applications like web browsers, file managers, or simple text editors. This prior exposure helps learners transition into more specialized areas (like command-line interfaces) without being overwhelmed.
+
+- **Understanding Core Concepts:**  
+  Grasping the basic idea of files, directories, and simple interactions with the operating system lays the groundwork for later learning. Without this, even basic computer literacy may be hard to achieve.
+
+## Key terms and Definitions
+
+- **Linux Kernel:**  
+  The core of the Linux operating system. It manages system resources (like memory and CPU), handles hardware interactions, and serves as the bridge between software and the computer's hardware.
+
+- **Command-Line Interface (CLI):**  
+  A text-based interface used to interact with the system. It lets you run commands, navigate directories, and perform tasks without a graphical user interface. Mastering the CLI is essential for efficient Linux administration.
+
+- **Shell:**  
+  A program (commonly Bash in Linux) that interprets the commands you type into the CLI. The shell enables scripting and automation, which are critical skills for managing systems.
+
+- **Terminal:**  
+  The application or window that provides you with a command-line interface. Think of it as the digital workspace where you enter and execute your commands.
+
+- **Filesystem Hierarchy:**  
+  The standardized directory structure in Linux (for example, `/etc`, `/var`, `/usr`) that organizes files and folders. Understanding this layout is crucial for locating configuration files and system resources.
+
+- **Package Manager (e.g., YUM/DNF):**  
+  A tool that automates the process of installing, updating, and removing software. In Red Hat environments, YUM or DNF is used to manage system packages and dependencies efficiently.
+
+- **Text Editors (VI/Vim):**  
+  Powerful command-line text editors used to create and edit configuration files and scripts. While there’s a learning curve, mastering VI/Vim is invaluable because they’re ubiquitous in Linux environments.
+
+- **Sudo:**  
+  A command that grants you temporary administrative privileges to execute tasks that require higher permissions. It’s a security measure that helps protect your system from unintended changes.
+
+- **File Permissions and Ownership:**  
+  The system that controls who can read, write, or execute files. Understanding permissions is key to maintaining system security and ensuring that only authorized users can modify critical files.
+
+- **Processes and Daemons:**  
+  Active programs on your system. Processes are tasks currently running, and daemons are background services that perform essential functions (like managing network connections or scheduled tasks).
+
+- **System Logs:**  
+  Files that record system events, errors, and security messages. Logs are your primary resource for troubleshooting and understanding system behavior during issues.
+
+- **Networking Basics:**  
+  Fundamental concepts such as IP addressing, DNS, and routing. A good grasp of networking is vital because Linux administrators frequently manage network configurations and troubleshoot connectivity issues.
+
+- **Bash Scripting:**  
+  The practice of writing scripts using the Bash shell to automate repetitive tasks. Scripting skills enhance efficiency and are highly valued in any Linux administration role.
+

--- a/.github/ISSUE_TEMPLATE/unit-lab-body.md
+++ b/.github/ISSUE_TEMPLATE/unit-lab-body.md
@@ -1,0 +1,420 @@
+# Example Lab from LAC Unit 1 Lab
+
+---
+
+<div class="flex-container">
+        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
+    <p>
+        <h1>Unit 1 Lab - Linux File Operations</h1>
+    </p>
+</div>
+
+> If you are unable to finish the lab in the ProLUG lab environment we ask you `reboot`
+> the machine from the command line so that other students will have the intended environment.
+
+### Resources / Important Links
+
+- [Killercoda Labs](https://killercoda.com/learn)
+- [Top 50+ Linux CLI Commands](https://www.digitalocean.com/community/tutorials/linux-commands)
+
+### Required Materials
+
+- Rocky 9.4+ - ProLUG Lab
+  - Or comparable Linux box
+- root or sudo command access
+
+#### Downloads
+
+The lab has been provided for convenience below:
+
+- <a href="./assets/downloads/u1/u1_lab.pdf" target="_blank" download>📥 u1_lab(`.pdf`)</a>
+- <a href="./assets/downloads/u1/u1_lab.docx" target="_blank" download>📥 u1_lab(`.docx`)</a>
+
+## Pre-Lab Warm-Up
+
+---
+
+EXERCISES (Warmup to quickly run through your system and familiarize yourself)
+
+```bash
+mkdir lab_essentials
+cd lab_essentials
+ls
+touch testfile1
+ls
+touch testfile{2..10}
+ls
+
+# What does this do differently?
+# Can you figure out what the size of those files are in bytes? What command did you use?
+
+touch file.`hostname`
+touch file.`hostname`.`date +%F`
+touch file.`hostname`.`date +%F`.`date +%s`
+ls
+
+# What do each of these values mean? `man date` to figure those values out.
+
+# Try to set the following values in the file
+
+# year, just two digits
+# today's day of the month
+# Just the century
+
+date +%y
+date +%e
+date +%C
+```
+
+## Lab 🧪
+
+---
+
+This lab is designed to help you get familiar with the basics of the systems you will be working on. Some of you will find that you know the basic material but the techniques here allow you to put it together in a more complex fashion.
+
+It is recommended that you type these commands and do not copy and paste them. Word sometimes likes to format characters and they don’t always play nice with Linux.
+
+#### Working with files:
+
+```bash
+# Creating empty files with touch
+touch fruits.txt
+
+ls -l fruits.txt
+# You will see that fruits.txt exists and is a 0 length (bytes) file
+
+-rw-r--r--. 1 root root 0 Jun 22 07:59 fruits.txt
+# Take a look at those values and see if you can figure out what they mean.
+# man touch and see if it has any other useful features you might use. If
+# you’ve ever used tiered storage think about access times and how to keep data
+# hot/warm/cold. If you haven’t just look around for a bit.
+
+rm -rf fruits.txt
+
+ls -l fruits.txt
+# You will see that fruits.txt is gone.
+```
+
+#### Creating files just by stuffing data in them:
+
+```bash
+echo “grapes 5” > fruits.txt
+cat fruits.txt
+echo “apples 3” > fruits.txt
+cat fruits.txt
+
+echo “ “ > fruits.txt
+
+echo “grapes 5” >> fruits.txt
+cat fruits.txt
+echo “apples 3” >> fruits.txt
+cat fruits.txt
+```
+
+What is the difference between these two? Appending a file >> adds to the file
+whereas > just overwrites the file each write. Log files almost always are written
+with >>, we never > over those types of files.
+
+#### Creating file with vi or vim:
+
+```bash
+# It is highly recommended the user read vimtutor. To get vimtutor follow
+# these steps:
+sudo -i
+yum -y install vim
+vimtutor
+
+# There are about 36 short labs to show a user how to get around inside of vi.
+# There are also cheat sheets around to help.
+
+vi somefile.txt
+# type “i” to enter insert mode
+
+# Enter the following lines
+grapes 5
+apples 7
+oranges 3
+bananas 2
+pears 6
+pineapples 9
+
+# hit the “esc” key at the top left of your keyboard
+# Type “:wq”
+# Hit enter
+
+cat somefile.txt
+```
+
+#### Copying and moving files:
+
+```bash
+cp somefile.txt backupfile.txt
+ls
+cat backupfile.txt
+mv somefile.txt fruits.txt
+ls
+cat fruits.txt
+```
+
+Look at what happened in each of these scenarios. Can you explain the
+difference between cp and mv? Read the manuals for cp and mv to see if
+there’s anything that may be useful to you. For most of us -r is tremendously
+useful option for moving directories.
+
+#### Searching/filtering through files:
+
+```bash
+# So maybe we only want to see certain values from a file, we can filter
+# with a tool called grep
+
+cat fruits.txt
+cat fruits.txt | grep apple
+cat fruits.txt | grep APPLE
+
+# read the manual for grep and see if you can cause it to ignore case.
+
+# See if you can figure out how to both ignore case and only find the
+# word apple at the beginning of the line.
+
+# If you can’t, here’s the the answer. Try it:
+cat fruits.txt | grep -i "^apple"
+```
+
+Can you figure out why that worked? What do you think the ^ does?
+Anchoring is a common term for this. See if you can find what anchors
+to the end of a string.
+
+#### Sorting files with sort:
+
+```bash
+# Let’s sort our file fruits.txt and look at what happens to the output
+# and the original file
+
+sort fruits.txt
+cat fruits.txt
+
+# Did the sort output come out different than the cat output? Did sorting
+# your file do anything to your original data? So let’s sort our data again
+# and figure out what this command does differently
+
+sort -k 2 fruits.txt
+
+# You can of course man sort to figure it out, but -k refers to the “key” and
+# can be useful for sorting by a specific column
+
+# But, if we cat fruits.txt we see we didn’t save anything we did. What if we
+# wanted to save these outputs into a file. Could you do it? If you couldn’t,
+# here’s an answer:
+
+sort fruits.txt > sort_by_alphabetical.txt
+sort -k 2 fruits.txt > sort_by_price.txt
+
+# Cat both of those files out and verify their output
+```
+
+#### Advanced sort practice:
+
+```bash
+# Consider the command
+ps -aux
+
+# But that’s too long to probably see everything, so let’s use a command
+# to filter just the top few lines
+ps -aux | head
+
+# So now you can see the actual fields (keys) across the top that we could sort by
+
+USER PID %CPU %MEM VSZ RSS TTY STAT START TIME COMMAND
+
+# So let’s say we wanted to sort by %MEM
+ps -aux | sort -k 4 -n -r | head -10
+```
+
+Read man to see why that works. Why do you suppose that it needs to be reversed
+to have the highest numbers at the top? What is the difference, if you can see any,
+between using the -n or not using it? You may have to use head -40 to figure that
+out, depending on your processes running.
+
+Read man ps to figure out what other things you can see or sort by from the ps command.
+We will examine that command in detail in another lab.
+
+#### Working with redirection:
+
+The good thing is that you’ve already been redirecting information into files. The > and >> are useful for moving data into files. We have other functionality within redirects that can prove useful for putting data where we want it, or even not seeing the data.
+
+Catching the input of one command and feeding that into the input of another command
+We’ve actually been doing this the entire time. “|” is the pipe operator and causes the output of one command to become the input of the second command.
+
+```bash
+cat fruits.txt | grep apple
+# This cats out the file, all of it, but then only shows the things that
+# pass through the filter of grep. We could continually add to these and make
+# them longer and longer
+
+cat fruits.txt | grep apple | sort | nl | awk ‘{print $2}’ | sort -r
+pineapples
+apples
+cat fruits.txt | grep apple | sort | nl | awk '{print $3}' | sort -r
+9
+7
+cat fruits.txt | grep apple | sort | nl | awk '{print $1}' | sort -r
+2
+1
+
+# Take these apart by pulling the end pipe and command off to see what is
+# actually happening:
+
+cat fruits.txt | grep apple | sort | nl | awk '{print $1}' | sort -r
+2
+1
+cat fruits.txt | grep apple | sort | nl | awk '{print $1}'
+1
+2
+cat fruits.txt | grep apple | sort | nl
+1 apples 7
+2 pineapples 9
+cat fruits.txt | grep apple | sort
+apples 7
+pineapples 9
+cat fruits.txt | grep apple
+apples 7
+pineapples 9
+```
+
+See if you can figure out what each of those commands do.
+Read the manual `man command` for any command you don’t recognize.
+Use something you learned to affect the output.
+
+#### Throwing the output into a file:
+
+We’ve already used > and >> to throw data into a file but when we redirect like that we are catching it before it comes to the screen. There is another tool that is useful for catching data and also showing it to us, that is tee.
+
+```bash
+date
+# comes to the screen
+
+date > datefile
+# redirects and creates a file datefile with the value
+
+date | tee -a datefile
+# will come to screen, redirect to the file.
+```
+
+Do a quick man on tee to see what the -a does. Try it without that value. Can you see any other useful options in there for tee?
+
+#### Ignoring pesky errors or tossing out unwanted output:
+
+Sometimes we don’t care when something errs out. We just want to see that it’s working or not. If you’re wanting to filter out errors (2) in the standarderr, you can do this
+
+```bash
+ls fruits.txt
+# You should see normal output
+
+ls fruity.txt
+# You should see an error unless you made this file
+
+ls fruity.txt 2> /dev/null
+# You should no longer see the error.
+
+# But, sometimes you do care how well your script runs against 100 servers,
+# or you’re testing and want to see those errors. You can redirect that to a file, just as easy
+
+ls fruity.txt 2> error.log
+cat error.log
+# You’ll see the error. If you want it see it a few times do the error line to see it happen.
+```
+
+In one of our later labs we’re going to look at stressing our systems out. For this, we’ll use a command that basically just causes the system to burn cpu cycles creating random numbers, zipping up the output and then throwing it all away. Here’s a preview of that command so you can play with it.
+
+May have to yum -y install bzip2 for this next one to work.
+
+```bash
+time dd if=/dev/urandom bs=1024k count=20 | bzip2 -9 >> /dev/null
+```
+
+Use “crtl + c” to break if you use that and it becomes too long or your system is under too much load. The only numbers you can play with there are the 1024k and the count. Other numbers should be only changed if you use man to read about them first.
+
+This is the “poor man’s” answer file. Something we used to do when we needed to answer some values into a script or installer. This is still very accurate and still works, but might be a bit advanced with a lot of advanced topics in here. Try it if you’d like but don’t worry if you don’t get this on the first lab.
+
+```bash
+vi testscript.sh
+hit “i” to enter insert mode
+add the following lines:
+
+#!/bin/bash
+
+read value
+echo "The first value is $value"
+read value
+echo "The second value is $value"
+read value
+echo "The third value is $value"
+read value
+echo "The fourth value is $value"
+
+# hit “esc” key
+type in :wq
+# hit enter
+
+chmod 755 testscript.sh
+
+# Now type in this (don’t type in the > those will just be there in your shell):
+
+[xgqa6cha@N01APL4244 ~]$ echo "yes
+
+> no
+> 10
+> why" | ./testscript.sh
+> yes
+> no
+> 10
+> why
+```
+
+What happened here is that we read the input from command line and gave it, in order to the script to read and then output. This is something we do if we know an installer wants certain values throughout it, but we don’t want to sit there and type them in, or we’re doing it across 100 servers quickly, or all kinds of reasons. It’s just a quick and dirty input “hack” that counts as a redirect.
+
+#### Working with permissions:
+
+Permissions have to do with who can or cannot access (read), edit (write), or execute (xecute)files.
+
+Permissions look like this.
+
+```bash
+ls -l
+```
+
+| Permission  | # of Links | UID Owner | Group Owner | Size (b) | Creation Month | Creation Day | Creation Time | File Name |
+| :---------: | :--------: | :-------: | :---------: | :------: | :------------: | :----------: | :-----------: | :-------: |
+| -rw-r--r--. |     1      |   Root    |    root     |    58    |      Jun       |      22      |     08:52     | datefile  |
+
+The primary permissions commands we’re going to use are going to be chmod (access) and chown (ownership).
+
+A quick rundown of how permissions break out:
+
+<img src='./assets/images/permissions.png'></img>
+
+Let’s examine some permissions and see if we can’t figure out what permissions are allowed.
+
+```bash
+ls -ld /root/
+# drwx------. 5 root root 4096 Jun 22 09:11 /root/
+```
+
+The first character lets you know if the file is a directory, file, or link. In this case we are looking at my home directory.
+
+`rwx`: For UID (me).
+
+- What permissions do I have?
+
+`---`: For group.
+
+- Who are they?
+- What can my group do?
+
+`---`: For everyone else.
+
+- What can everyone else do?
+
+Go find some other interesting files or directories and see what you see there. Can you identify their characteristics and permissions?
+
+> Be sure to `reboot` the lab machine from the command line when you are done.

--- a/.github/ISSUE_TEMPLATE/unit-worksheet-body.md
+++ b/.github/ISSUE_TEMPLATE/unit-worksheet-body.md
@@ -1,0 +1,139 @@
+# Example Worksheet from LAC Unit 1 Worksheet
+
+---
+
+<div class="flex-container">
+        <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
+    <p>
+        <h1>Unit 1 Worksheet - Linux File Operations</h1>
+    </p>
+</div>
+
+## Instructions
+
+---
+
+Fill out the worksheet as you progress through the lab and discussions.
+Hold your worksheets until the end to turn them in as a final submission packet.
+
+### Resources / Important Links
+
+- [What is Vim?](https://github.com/vim/vim)
+- [The Linux Foundation](https://www.linux.org/pages/download/)
+- [Linux CLI Cheatsheets](https://www.digitalocean.com/community/tutorials/linux-commands)
+
+#### Downloads
+
+The worksheet has been provided below. The document(s) can be transposed to
+the desired format so long as the content is preserved. For example, the `.txt`
+could be transposed to a `.md` file.
+
+- <a href="./assets/downloads/u1/u1_worksheet.txt" target="_blank" download>📥 u1_worksheet(`.txt`)</a>
+- <a href="./assets/downloads/u1/u1_worksheet.docx" target="_blank" download>📥 u1_worksheet(`.docx`)</a>
+
+### Unit 1 Recording
+
+<iframe
+    style="width: 100%; height: 100%; border: none;
+    aspect-ratio: 16/9; border-radius: 1rem; background:black"
+    src="https://www.youtube.com/embed/eHB8WKWz2eQ"
+    title="Unit 1 Recording - ProLUG Linux Systems Administration Course - Free in Discord"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    referrerpolicy="strict-origin-when-cross-origin"
+    allowfullscreen>
+</iframe>
+
+#### Discussion Post #1
+
+Using a 0-10 system, rate yourself on how well you think you know each topic in the table below. (You do not have to post this rating).
+
+<div style="display: flex; justify-content: left;">
+
+|   Skill    | High (8-10) | Mid (4-7) | Low (0-3) | Total |
+| :--------: | :---------: | :-------: | :-------: | :---: |
+|   Linux    |             |           |           |       |
+|  Storage   |             |           |           |       |
+|  Security  |             |           |           |       |
+| Networking |             |           |           |       |
+|    Git     |             |           |           |       |
+| Automation |             |           |           |       |
+| Monitoring |             |           |           |       |
+|  Database  |             |           |           |       |
+|   Cloud    |             |           |           |       |
+| Kubernetes |             |           |           |       |
+|   Total    |             |           |           |       |
+
+</div>
+
+Next, answer these questions here:
+
+1. What do you hope to learn in this course?
+
+2. What type of career path are you shooting for?
+
+#### Discussion Post #2
+
+1. Post a job that you are interested in from a local job website. (link or image)
+
+2. What do you know how to do in the posting?
+
+3. What don't you know how to do in the posting?
+
+4. What are you doing to close the gap? What can you do to remedy the difference?
+
+<div class="warning">
+Submit your input by following the link below.
+
+The discussion posts are done in Discord threads. Click the 'Threads' icon on the top right and search for the discussion post.
+
+</div>
+
+- [Link to Discussion Posts](https://discord.com/channels/611027490848374811/1098309490681598072)
+
+### Start thinking about your project ideas (more to come in future weeks):
+
+Topics:
+
+1. System Stability
+2. System Performance
+3. System Security
+4. System monitoring
+5. Kubernetes
+6. Programming/Automation
+
+You will research, design, deploy, and document a system that improves your administration of Linux systems in some way.
+
+## Definitions
+
+---
+
+Kernel:
+
+Kernel Args:
+
+OS Version:
+
+Modules:
+
+Mount Points:
+
+Text Editor:
+
+## Digging Deeper
+
+---
+
+1. Use vimtutor and see how far you get. What did you learn that you did not know about vi/vim?
+
+2. Go to <https://vim-adventures.com/> and see how far you get. What did you learn that you did not already know about vi/vim?
+
+3. Go to <https://www.youtube.com/watch?v=d8XtNXutVto> and see how far you get with vim. What did you learn that you did not already know about vi/vim?
+
+## Reflection Questions
+
+---
+
+1. What questions do you still have about this week?
+
+2. How are you going to use what you’ve learned in your current role?

--- a/scripts/create-issues
+++ b/scripts/create-issues
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+declare UNIT
+declare TYPE
+declare FILE
+declare EMOJI
+declare PROJECT
+
+case $PWD in
+    *lac*)
+        PROJECT='lac'
+        ;;
+    *psc*)
+        PROJECT='pscpm'
+        ;;
+esac
+
+
+while [[ -n $1 ]]; do
+    case $1 in
+        -u|--unit)
+            [[ -n $2 ]] && UNIT=$2 || printf "Bad argument to -u/--unit.\n"
+            shift; shift;
+            ;;
+        -t|--type)
+            [[ -n $2 ]] && TYPE=$2 || printf "No argument to -t/--type.\n"
+            shift; shift;
+            ;;
+        -h|--help)
+            cat <<- EOF
+            NAME: create-issues
+            USAGE:
+              create-issues -t|--type TYPE -u|--unit UNIT_NUMBER
+
+            OPTIONS:
+                -u | --unit UNIT_NUMBER     Specify the unit number for the issue 
+                -t | --type TYPE            Specify the type of document for the issue 
+                                            This can be one of 'worksheet', 'lab', 'intro', 'bonus'
+
+            SYNOPSIS:
+            Creates an issue for the upstream repo. The 'gh' tool must be configured beforehand.
+			EOF
+    esac
+done
+
+
+case $TYPE in
+    ws|worksheet)
+        FILE="u${UNIT}ws.md"
+        EMOJI="📄"
+        LABEL="Worksheet ${EMOJI}"
+        ;;
+    l|lab)
+        FILE="u${UNIT}lab.md"
+        EMOJI="🧪"
+        LABEL="Lab ${EMOJI}"
+        ;;
+    i|intro)
+        FILE="u${UNIT}intro.md"
+        EMOJI="👋"
+        LABEL="Intro"
+        ;;
+    b|bonus)
+        FILE="u${UNIT}b.md"
+        EMOJI="🍒"
+        LABEL="Bonus ${EMOJI}"
+        ;;
+esac
+
+gh issue create \
+    --title "Unit ${UNIT} ${TYPE^} ${EMOJI} (${FILE})" \
+    --label "${LABEL}" \
+    --label "Unit #${UNIT}" \
+    --label "help wanted" \
+    --label "enhancement" \
+    --label "good first issue" \
+    --body "$(cat ./.github/ISSUE_TEMPLATE/unit-"${TYPE,,}"-body.md)" || {
+    printf >&2 "Failed to create the issue!\n" && exit 1
+}
+    # --project "pscpm" \ # doesn't work
+

--- a/scripts/create-issues
+++ b/scripts/create-issues
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Make sure you're authenticated via 'gh auth login', with a PAT with correct access.  
+# Run from inside the `scripts` directory.
 
 declare UNIT
 declare TYPE
@@ -40,6 +42,9 @@ while [[ -n $1 ]]; do
             SYNOPSIS:
             Creates an issue for the upstream repo. The 'gh' tool must be configured beforehand.
 			EOF
+            shift;
+            exit 0
+            ;;
     esac
 done
 
@@ -74,7 +79,7 @@ gh issue create \
     --label "help wanted" \
     --label "enhancement" \
     --label "good first issue" \
-    --body "$(cat ./.github/ISSUE_TEMPLATE/unit-"${TYPE,,}"-body.md)" || {
+    --body "$(cat ../.github/ISSUE_TEMPLATE/unit-"${TYPE,,}"-body.md)" || {
     printf >&2 "Failed to create the issue!\n" && exit 1
 }
     # --project "pscpm" \ # doesn't work

--- a/scripts/create-issues
+++ b/scripts/create-issues
@@ -51,21 +51,25 @@ done
 
 case $TYPE in
     ws|worksheet)
+        TYPE='worksheet'
         FILE="u${UNIT}ws.md"
         EMOJI="📄"
         LABEL="Worksheet ${EMOJI}"
         ;;
     l|lab)
+        TYPE='lab'
         FILE="u${UNIT}lab.md"
         EMOJI="🧪"
         LABEL="Lab ${EMOJI}"
         ;;
     i|intro)
+        TYPE='intro'
         FILE="u${UNIT}intro.md"
         EMOJI="👋"
         LABEL="Intro"
         ;;
     b|bonus)
+        TYPE='bonus'
         FILE="u${UNIT}b.md"
         EMOJI="🍒"
         LABEL="Bonus ${EMOJI}"

--- a/scripts/create-issues
+++ b/scripts/create-issues
@@ -32,7 +32,7 @@ while [[ -n $1 ]]; do
             cat <<- EOF
             NAME: create-issues
             USAGE:
-              create-issues -t|--type TYPE -u|--unit UNIT_NUMBER
+              create-issues [-t|--type TYPE] [-u|--unit UNIT_NUMBER]
 
             OPTIONS:
                 -u | --unit UNIT_NUMBER     Specify the unit number for the issue 
@@ -48,6 +48,8 @@ while [[ -n $1 ]]; do
     esac
 done
 
+[[ -z $UNIT ]] && read -r -p "Enter unit number: " UNIT || printf "No unit!\n" && exit 1
+[[ -z $TYPE ]] && read -r -p "Enter type (ws/lab/intro/bonus): " TYPE || printf "No type!\n" && exit 1
 
 case $TYPE in
     ws|worksheet)


### PR DESCRIPTION
I wanted to take the manual labor out of creating 4 issues for each unit.  
This uses the `gh` command line tool to create issues on the repo, and reads from files in `.github/ISSUE_TEMPLATES` for the body of the issues.

The GH CLI tool must be configured on your local system with `gh auth login`, and the access token you use must have the correct permissions to create issues for the org.  

Follows the same format that has been used all through lac and psc so far.

Ex: Create a worksheet issue for unit 5
```bash
cd ./scripts
./create-issues -u 5 -t worksheet
```
repeat with `-t intro`, `-t lab`, `-t bonus`.  

Limitation is that you cannot specify "Type" via the `gh` tool so that will need to be manually added.