### PR TITLE
fix: Unit 7 lab fixes and style changes

### DIFF
--- a/src/u7lab.md
+++ b/src/u7lab.md
@@ -33,7 +33,7 @@ These labs focus on pulling metric information and then visualizing that data qu
 
 <img src='./assets/images/u7/image1.png'></img>
 
-1. Complete the lab: <https://killercoda.com/het-tanis/course/Linux-Labs/109-fail2ban-with-logmonitoring>
+1. Complete the lab: <https://killercoda.com/het-tanis/course/Linux-Labs/109-fail2ban-with-log-monitoring>
 
    - Were you able to see the IP address that was banned and unban it?
 
@@ -46,7 +46,7 @@ These labs focus on pulling metric information and then visualizing that data qu
 
 <img src='./assets/images/u7/image2.png'></img>
 
-1. Complete the lab here: <https://killercoda.com/het-tanis/course/Linux-Labs/110-fail2ban-withmetric-alerting>
+1. Complete the lab here: <https://killercoda.com/het-tanis/course/Linux-Labs/110-fail2ban-with-metric-alerting>
 
    - Do you see `fail2ban` in the Grafana Dashboard? If not, how are you going to
      troubleshoot it?
@@ -66,7 +66,7 @@ These labs focus on pulling metric information and then visualizing that data qu
    - Which of the receivers do you have experience with?
 
 2. Review the Grafana alert thresholds:
-   <https://grafana.com/docs/grafana/latest/panelsvisualizations/configure-thresholds/>
+   <https://grafana.com/docs/grafana/latest/panels-visualizations/configure-thresholds/>
 
    - Can you modify one of the thresholds from the lab to trigger into the discord?
 

--- a/src/u7lab.md
+++ b/src/u7lab.md
@@ -1,7 +1,7 @@
 <div class="flex-container">
         <img src="https://github.com/ProfessionalLinuxUsersGroup/img/blob/main/Assets/Logos/ProLUG_Round_Transparent_LOGO.png?raw=true" width="64" height="64"></img>
     <p>
-        <h1>Under Construction</h1>
+        <h1>Unit 7 Lab - Monitoring and Alerting</h1>
     </p>
 </div>
 
@@ -23,52 +23,53 @@ the desired format so long as the content is preserved. For example, the `.txt`
 could be transposed to a `.md` file.
 
 - <a href="./assets/downloads/u7/u7_lab.txt" target="_blank" download>📥 u7_lab(`.txt`)</a>
-- <a href="./assets/downloads/u7/u7_lab.docx" target="_blank" download>📥 u7_lab(`.docx`)</a>
+- <a href="./assets/downloads/u7/u7_lab.pdf" target="_blank" download>📥 u7_lab(`.pdf`)</a>
 
 ## Lab 🧪
 
 These labs focus on pulling metric information and then visualizing that data quickly on dashboards for real time analysis.
 
 ### Monitoring Jails with Fail2ban logs
+
 <img src='./assets/images/u7/image1.png'></img>
 
-1. Complete the lab: https://killercoda.com/het-tanis/course/Linux-Labs/109-fail2ban-with-logmonitoring
- - Were you able to see the IP address that was banned and unban it?
+1. Complete the lab: <https://killercoda.com/het-tanis/course/Linux-Labs/109-fail2ban-with-logmonitoring>
 
- - Were you able to see all the NOTICE events in Grafana?
+   - Were you able to see the IP address that was banned and unban it?
 
- - What other questions do you have about this lab, and how might you go figure
-them out?
+   - Were you able to see all the NOTICE events in Grafana?
+
+   - What other questions do you have about this lab, and how might you go figure them
+     out?
 
 ### Monitoring Jails with Fail2ban and telemetry data
+
 <img src='./assets/images/u7/image2.png'></img>
 
+1. Complete the lab here: <https://killercoda.com/het-tanis/course/Linux-Labs/110-fail2ban-withmetric-alerting>
 
-1. Complete the lab here: https://killercoda.com/het-tanis/course/Linux-Labs/110-fail2ban-withmetric-alerting
+   - Do you see `fail2ban` in the Grafana Dashboard? If not, how are you going to
+     troubleshoot it?
 
- - Do you see fail2ban in the Grafana Dashboard? If not, how are you going to
-troubleshoot it?
+   - Did you get your test alert and then real alert to trigger into the Discord channel?
 
- - Did you get your test alert and then real alert to trigger into the Discord channel?
-
- - What other applications or uses for this could you think of? Do you have other
-places you could send alerts that would help you professionally?
-
+   - What other applications or uses for this could you think of? Do you have other
+     places you could send alerts that would help you professionally?
 
 ## Digging Deeper challenge (not required for finishing lab)
 
 1. Review the alert manager documentation:
-https://prometheus.io/docs/alerting/latest/configuration/
+   <https://prometheus.io/docs/alerting/latest/configuration/>
 
- - What are all the types of receivers you see?
+   - What are all the types of receivers you see?
 
- - Which of the receivers do you have experience with?
+   - Which of the receivers do you have experience with?
 
-2. Review the Grafana alert thresholds: 
-https://grafana.com/docs/grafana/latest/panelsvisualizations/configure-thresholds/
+2. Review the Grafana alert thresholds:
+   <https://grafana.com/docs/grafana/latest/panelsvisualizations/configure-thresholds/>
 
- - Can you modify one of the thresholds from the lab to trigger into the discord?
+   - Can you modify one of the thresholds from the lab to trigger into the discord?
 
- - What is the relationship between critical and warning by default?
+   - What is the relationship between critical and warning by default?
 
 > Be sure to `reboot` the lab machine from the command line when you are done.


### PR DESCRIPTION
Changed unit 7's header from "Under Construction," made links clickable, changed the `.docx` download to `.pdf`.   
Indented questions and formatted with `prettier`.  