### PR TITLE
feat: Add 'create all' functionality to issue gen script

### DIFF
--- a/scripts/create-issues
+++ b/scripts/create-issues
@@ -7,6 +7,82 @@ declare TYPE
 declare FILE
 declare EMOJI
 declare PROJECT
+declare TEMPL_PATH
+
+declare -a ALL_TYPES=('intro' 'worksheet' 'lab' 'bonus')
+
+_set_type_vars() {
+    # Pass in $TYPE
+    case $1 in
+        ws|worksheet)
+            TYPE='worksheet'
+            FILE="u${UNIT}ws.md"
+            EMOJI="📄"
+            LABEL="Worksheet ${EMOJI}"
+            ;;
+        l|lab)
+            TYPE='lab'
+            FILE="u${UNIT}lab.md"
+            EMOJI="🧪"
+            LABEL="Lab ${EMOJI}"
+            ;;
+        i|intro)
+            TYPE='intro'
+            FILE="u${UNIT}intro.md"
+            EMOJI="👋"
+            LABEL="Intro"
+            ;;
+        b|bonus)
+            TYPE='bonus'
+            FILE="u${UNIT}b.md"
+            EMOJI="🍒"
+            LABEL="Bonus ${EMOJI}"
+            ;;
+    esac
+}
+
+
+while [[ -n $1 ]]; do
+    case $1 in
+        -u|--unit)
+            [[ -n $2 ]] && UNIT=$2 && shift || printf "Bad argument to -u/--unit.\n"
+            shift;
+            ;;
+        -t|--type)
+            [[ -n $2 ]] && TYPE=$2 && shift || printf "No argument to -t/--type.\n"
+            shift; 
+            ;;
+        -a|--all)
+            TYPE="all"
+            shift;
+            ;;
+        -h|--help)
+            cat <<- EOF
+            NAME: create-issues
+            USAGE:
+              create-issues [-t|--type TYPE] [-u|--unit UNIT_NUMBER] [-a|--all]
+
+            OPTIONS:
+                -u | --unit UNIT_NUMBER     Specify the unit number for the issue 
+                -t | --type TYPE            Specify the type of document for the issue 
+                                            This can be one of 'worksheet', 'lab', 'intro', 'bonus'. Set to 'all' to create an issue of each type.
+                -a | --all                  Shorthand for '--type all'
+
+            SYNOPSIS:
+            Creates an issue for the upstream repo. The 'gh' tool must be configured beforehand.
+			EOF
+            shift;
+            exit 0
+            ;;
+    esac
+done
+
+[[ -z $UNIT ]] && read -r -p "Enter unit number: " UNIT;  
+[[ -z $TYPE ]] && read -r -p "Enter type (ws/lab/intro/bonus/all): " TYPE;  
+[[ -z $TYPE || -z $UNIT ]] && printf "Missing Type or Unit!\n" && exit 1
+[[ "${PWD##*/}" == scripts ]] &&
+    TEMPL_PATH="../.github/ISSUE_TEMPLATE" ||
+    TEMPL_PATH=".github/ISSUE_TEMPLATE"
 
 case $PWD in
     *lac*)
@@ -18,77 +94,35 @@ case $PWD in
 esac
 
 
-while [[ -n $1 ]]; do
-    case $1 in
-        -u|--unit)
-            [[ -n $2 ]] && UNIT=$2 || printf "Bad argument to -u/--unit.\n"
-            shift; shift;
-            ;;
-        -t|--type)
-            [[ -n $2 ]] && TYPE=$2 || printf "No argument to -t/--type.\n"
-            shift; shift;
-            ;;
-        -h|--help)
-            cat <<- EOF
-            NAME: create-issues
-            USAGE:
-              create-issues [-t|--type TYPE] [-u|--unit UNIT_NUMBER]
+if [[ "${TYPE,,}" == "all" ]]; then
+    for t in "${ALL_TYPES[@]}"; do
+        _set_type_vars "$t"
+        gh issue create \
+            --title "Unit ${UNIT} ${t^} ${EMOJI} (${FILE})" \
+            --label "${LABEL}" \
+            --label "Unit #${UNIT}" \
+            --label "help wanted" \
+            --label "enhancement" \
+            --body-file "$TEMPL_PATH/unit-${t,,}-body.md" || {
+            printf >&2 "Failed to create the issue!\n" && exit 1
+        }
+    done
+    printf "Successfully created all issues for unit %s.\n" "$UNIT"
+    exit 0
+else
+    _set_type_vars "$TYPE"
+    gh issue create \
+        --title "Unit ${UNIT} ${TYPE^} ${EMOJI} (${FILE})" \
+        --label "${LABEL}" \
+        --label "Unit #${UNIT}" \
+        --label "help wanted" \
+        --label "enhancement" \
+        --body-file "$TEMPL_PATH/unit-${TYPE,,}-body.md" || {
+        printf >&2 "Failed to create the issue!\n" && exit 1
+    }
+    printf "Successfully created %s issue for unit %s.\n" "$TYPE" "$UNIT"
+    exit 0
+fi
 
-            OPTIONS:
-                -u | --unit UNIT_NUMBER     Specify the unit number for the issue 
-                -t | --type TYPE            Specify the type of document for the issue 
-                                            This can be one of 'worksheet', 'lab', 'intro', 'bonus'
-
-            SYNOPSIS:
-            Creates an issue for the upstream repo. The 'gh' tool must be configured beforehand.
-			EOF
-            shift;
-            exit 0
-            ;;
-    esac
-done
-
-{ [[ -z $UNIT ]] && read -r -p "Enter unit number: " UNIT; } 
-{ [[ -z $TYPE ]] && read -r -p "Enter type (ws/lab/intro/bonus): " TYPE; } 
-
-[[ -z $TYPE || -z $UNIT ]] && printf "Missing Type or Unit!\n"
-
-case $TYPE in
-    ws|worksheet)
-        TYPE='worksheet'
-        FILE="u${UNIT}ws.md"
-        EMOJI="📄"
-        LABEL="Worksheet ${EMOJI}"
-        ;;
-    l|lab)
-        TYPE='lab'
-        FILE="u${UNIT}lab.md"
-        EMOJI="🧪"
-        LABEL="Lab ${EMOJI}"
-        ;;
-    i|intro)
-        TYPE='intro'
-        FILE="u${UNIT}intro.md"
-        EMOJI="👋"
-        LABEL="Intro"
-        ;;
-    b|bonus)
-        TYPE='bonus'
-        FILE="u${UNIT}b.md"
-        EMOJI="🍒"
-        LABEL="Bonus ${EMOJI}"
-        ;;
-esac
-
-gh issue create \
-    --title "Unit ${UNIT} ${TYPE^} ${EMOJI} (${FILE})" \
-    --label "${LABEL}" \
-    --label "Unit #${UNIT}" \
-    --label "help wanted" \
-    --label "enhancement" \
-    --label "good first issue" \
-    --body "$(cat ../.github/ISSUE_TEMPLATE/unit-"${TYPE,,}"-body.md)" || {
-    printf >&2 "Failed to create the issue!\n" && exit 1
-}
-    # --project "pscpm" \ # doesn't work
+# --project "$PROJECT" \ # doesn't work
 


### PR DESCRIPTION
Added `--type all` to create all 4 issues for a single unit. Alternatively use the `-a|--all` option (`-u|--unit` still required).  

Fixed an error where issue template wasn't being loaded properly depending on `$PWD`.  